### PR TITLE
Added more headers & horizontal rule support

### DIFF
--- a/Formatting_Sample.md
+++ b/Formatting_Sample.md
@@ -1,6 +1,15 @@
 # Markdown Formatting
 ## Start Test!
 #1 in the galaxy
+
+Horizontal rules!
+With asterisks,
+***
+hyphens
+---
+and underscores
+___
+
 Emphasis, aka italics, with *asterisks* or _underscores_.
 Strong emphasis, aka bold, with **asterisks** or __underscores__.
 Combined emphasis with **asterisks and _underscores_**.

--- a/Formatting_Sample.md
+++ b/Formatting_Sample.md
@@ -1,5 +1,7 @@
 # Markdown Formatting
 ## Start Test!
+### More headers!
+#### Unsupported header, but should render the same as above.
 #1 in the galaxy
 
 Horizontal rules!

--- a/NPP_Macro/shortcuts.xml
+++ b/NPP_Macro/shortcuts.xml
@@ -13,9 +13,21 @@
             <Action type="3" message="1702" wParam="0" lParam="768" sParam="" />
             <Action type="3" message="1701" wParam="0" lParam="1609" sParam="" />
             <Action type="3" message="1700" wParam="0" lParam="0" sParam="" />
-            <Action type="3" message="1601" wParam="0" lParam="0" sParam="^#+\s(.*)$" />
+            <Action type="3" message="1601" wParam="0" lParam="0" sParam="^#\s(.*)$" />
             <Action type="3" message="1625" wParam="0" lParam="2" sParam="" />
             <Action type="3" message="1602" wParam="0" lParam="0" sParam="[h1]$1[/h1]" />
+            <Action type="3" message="1702" wParam="0" lParam="768" sParam="" />
+            <Action type="3" message="1701" wParam="0" lParam="1609" sParam="" />
+            <Action type="3" message="1700" wParam="0" lParam="0" sParam="" />
+            <Action type="3" message="1601" wParam="0" lParam="0" sParam="^##\s(.*)$" />
+            <Action type="3" message="1625" wParam="0" lParam="2" sParam="" />
+            <Action type="3" message="1602" wParam="0" lParam="0" sParam="[h2]$1[/h2]" />
+            <Action type="3" message="1702" wParam="0" lParam="768" sParam="" />
+            <Action type="3" message="1701" wParam="0" lParam="1609" sParam="" />
+            <Action type="3" message="1700" wParam="0" lParam="0" sParam="" />
+            <Action type="3" message="1601" wParam="0" lParam="0" sParam="^###+\s(.*)$" />
+            <Action type="3" message="1625" wParam="0" lParam="2" sParam="" />
+            <Action type="3" message="1602" wParam="0" lParam="0" sParam="[h3]$1[/h3]" />
             <Action type="3" message="1702" wParam="0" lParam="768" sParam="" />
             <Action type="3" message="1701" wParam="0" lParam="1609" sParam="" />
             <Action type="3" message="1700" wParam="0" lParam="0" sParam="" />

--- a/NPP_Macro/shortcuts.xml
+++ b/NPP_Macro/shortcuts.xml
@@ -31,6 +31,12 @@
             <Action type="3" message="1702" wParam="0" lParam="768" sParam="" />
             <Action type="3" message="1701" wParam="0" lParam="1609" sParam="" />
             <Action type="3" message="1700" wParam="0" lParam="0" sParam="" />
+            <Action type="3" message="1601" wParam="0" lParam="0" sParam="^[*-_]{3,}$" />
+            <Action type="3" message="1625" wParam="0" lParam="2" sParam="" />
+            <Action type="3" message="1602" wParam="0" lParam="0" sParam="[hr][/hr]" />
+            <Action type="3" message="1702" wParam="0" lParam="768" sParam="" />
+            <Action type="3" message="1701" wParam="0" lParam="1609" sParam="" />
+            <Action type="3" message="1700" wParam="0" lParam="0" sParam="" />
             <Action type="3" message="1601" wParam="0" lParam="0" sParam="~{2}(.*)~{2}" />
             <Action type="3" message="1625" wParam="0" lParam="2" sParam="" />
             <Action type="3" message="1602" wParam="0" lParam="0" sParam="[strike]$1[/strike]" />

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ See a RegEx pattern that needs improvement? Send in a Pull Request with some exa
 
 ## Credits ## 
 * KongMD - NPP macro and RegEx patterns
-* GreatGrogrodor - Extended support for steam formatting.
+* GeorgeBroughton - Extended support for steam formatting.

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ See a RegEx pattern that needs improvement? Send in a Pull Request with some exa
 
 ## Credits ## 
 * KongMD - NPP macro and RegEx patterns
+* GreatGrogrodor - Extended support for steam formatting.

--- a/RegEx_Patterns.txt
+++ b/RegEx_Patterns.txt
@@ -18,6 +18,10 @@ Header 3
 F: ^###+\s(.*)$
 R: [h3]$1[/h3]
 
+Horizontal Rule
+F: ^[*-_]{3,}$
+R: [hr][/hr]
+
 Strikethrough
 F: ~{2}(.*)~{2}
 R: [strike]$1[/strike]

--- a/RegEx_Patterns.txt
+++ b/RegEx_Patterns.txt
@@ -6,9 +6,17 @@ Hack (used as a helper for Unordered List pattern matching)
 F: \z
 R: \r\n 
 
-Headers
-F: ^#+\s(.*)$
+Header 1
+F: ^#\s(.*)$
 R: [h1]$1[/h1]
+
+Header 2
+F: ^##\s(.*)$
+R: [h2]$1[/h2]
+
+Header 3
+F: ^###\s(.*)$
+R: [h3]$1[/h3]
 
 Strikethrough
 F: ~{2}(.*)~{2}

--- a/RegEx_Patterns.txt
+++ b/RegEx_Patterns.txt
@@ -15,7 +15,7 @@ F: ^##\s(.*)$
 R: [h2]$1[/h2]
 
 Header 3
-F: ^###\s(.*)$
+F: ^###+\s(.*)$
 R: [h3]$1[/h3]
 
 Strikethrough


### PR DESCRIPTION
 - Edited header support for [h1][/h1] so it didn't apply to all headers
 - Added support for [h2][/h2] and [h3][/h3]
 - Horizontal rules added, compatible with the 3 main types: using hyphens, underscores and asterisks
 - Docs updated to reflect changes